### PR TITLE
Update streamingclient.py

### DIFF
--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -4,6 +4,10 @@ import websocket
 import threading
 import six
 import json
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
 
 
 def on_error(error):
@@ -62,8 +66,10 @@ class RevAiStreamingClient():
 
         :param generator: generator object that yields binary audio data
         """
-        url = self.base_url + '?access_token={}'.format(self.access_token) \
-            + '&content_type={}'.format(self.config.get_content_type_string())
+        url = self.base_url + '?' + urlencode({
+            'access_token': self.access_token,
+            'content_type': self.config.get_content_type_string()
+        })
 
         try:
             self.client.connect(url)

--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -66,7 +66,7 @@ class RevAiStreamingClient():
 
         :param generator: generator object that yields binary audio data
         """
-        url = self.base_url + '?' + urlencode({
+        url = self.base_url + '/?' + urlencode({
             'access_token': self.access_token,
             'content_type': self.config.get_content_type_string()
         })


### PR DESCRIPTION
https://tools.ietf.org/html/rfc1738 section 3.3
>  Within the <path> and <searchpart> components, "/", ";", "?" are reserved.

So you should be encoding it even though the server is lenient.

Also, this is the first time I've seen a content type in a query string. Is that a websocket thing?