### PR TITLE
Added detailed_partials parameter to start streaming method

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If passing in custom functions, make sure you provide the right parameters. See 
 
 Once you have a streaming client setup with a `MediaConfig` and access token, you can obtain a transcription generator of your audio. You can also use a custom vocabulary with your streaming job by supplying the optional `custom_vocabulary_id` when starting a connection!
 
-More optional parameters can be supplied when starting a connection, these are `metadata`, `filter_profanity`, `remove_disfluencies`, and `delete_after_seconds`. For a description of these optional parameters look at our [streaming documentation](https://www.rev.ai/docs/streaming#section/WebSocket-Endpoint).
+More optional parameters can be supplied when starting a connection, these are `metadata`, `filter_profanity`, `remove_disfluencies`, `delete_after_seconds`, and `detailed_partials`. For a description of these optional parameters look at our [streaming documentation](https://www.rev.ai/docs/streaming#section/WebSocket-Endpoint).
 
 ```python
 response_generator = streaming_client.start(AUDIO_GENERATOR, custom_vocabulary_id="CUSTOM VOCAB ID")
@@ -216,9 +216,12 @@ Remember in your development to follow the PEP8 style guide. Your code editor li
 # Local testing instructions
 
 Prequisites: virtualenv, tox
+
 To test locally use the following commands from the repo root
+
     virtualenv ./sdk-test
     . ./sdk-test/bin/activate
     tox
+
 This will locally run the test suite, and saves significant dev time over
 waiting for the CI tool to pick it up.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.12.1
+current_version = 2.13.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.12.0
+current_version = 2.12.1
 commit = True
 tag = True
 

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Top-level package for rev_ai"""
 
-__version__ = '2.12.1'
+__version__ = '2.13.0'
 
 from .models import Job, JobStatus, Account, Transcript, MediaConfig, CaptionType, CustomVocabulary

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Top-level package for rev_ai"""
 
-__version__ = '2.12.0'
+__version__ = '2.12.1'
 
 from .models import Job, JobStatus, Account, Transcript, MediaConfig, CaptionType, CustomVocabulary

--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -67,7 +67,8 @@ class RevAiStreamingClient():
               custom_vocabulary_id=None,
               filter_profanity=None,
               remove_disfluencies=None,
-              delete_after_seconds=None):
+              delete_after_seconds=None,
+              detailed_partials=None):
         """Function to connect the websocket to the URL and start the response
             thread
         :param generator: generator object that yields binary audio data
@@ -76,6 +77,7 @@ class RevAiStreamingClient():
         :param filter_profanity: whether to mask profane words
         :param remove_disfluencies: whether to exclude filler words like "uh"
         :param delete_after_seconds: number of seconds after job completion when job is auto-deleted
+        :param detailed_partials: wheter to receive timestamps and confidence scores 
         """
         url = self.base_url + '?' + urlencode({
             'access_token': self.access_token,
@@ -97,6 +99,9 @@ class RevAiStreamingClient():
 
         if delete_after_seconds is not None:
             url += '&' + urlencode({'delete_after_seconds': delete_after_seconds})
+            
+        if detailed_partials:
+            url += '&' + urlencode({'detailed_partials': 'true'})
 
         try:
             self.client.connect(url)

--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -77,7 +77,7 @@ class RevAiStreamingClient():
         :param filter_profanity: whether to mask profane words
         :param remove_disfluencies: whether to exclude filler words like "uh"
         :param delete_after_seconds: number of seconds after job completion when job is auto-deleted
-        :param detailed_partials: wheter to receive timestamps and confidence scores 
+        :param detailed_partials: whether to receive timestamps and confidence scores 
         """
         url = self.base_url + '?' + urlencode({
             'access_token': self.access_token,

--- a/tests/test_streamingclient.py
+++ b/tests/test_streamingclient.py
@@ -74,7 +74,11 @@ class TestStreamingClient():
 
         called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]
         validate_query_parameters(called_url, expected_query_dict)
-        validate_stream_client(mock_streaming_client)
+        assert mock_streaming_client.client.connect.call_count == 1
+        mock_streaming_client.client.send_binary.assert_any_call(0)
+        mock_streaming_client.client.send_binary.assert_any_call(1)
+        mock_streaming_client.client.send_binary.assert_any_call(2)
+        assert hasattr(mock_streaming_client, 'request_thread')
         for ind, response in enumerate(response_gen):
             assert capsys.readouterr().out == exp_responses[ind]
             assert exp_responses[ind + 1] == response
@@ -116,7 +120,11 @@ class TestStreamingClient():
 
         called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]
         validate_query_parameters(called_url, expected_query_dict)
-        validate_stream_client(mock_streaming_client)
+        assert mock_streaming_client.client.connect.call_count == 1
+        mock_streaming_client.client.send_binary.assert_any_call(0)
+        mock_streaming_client.client.send_binary.assert_any_call(1)
+        mock_streaming_client.client.send_binary.assert_any_call(2)
+        assert hasattr(mock_streaming_client, 'request_thread')
         for ind, response in enumerate(response_gen):
             assert capsys.readouterr().out == exp_responses[ind]
             assert exp_responses[ind + 1] == response
@@ -161,10 +169,3 @@ def validate_query_parameters(called_url, expected_query_dict):
     called_query_parameters = parse_qs(called_query_string)
     for key in expected_query_dict:
         assert called_query_parameters[key][0] == expected_query_dict[key]
-
-def validate_stream_client(mock_streaming_client):
-    assert mock_streaming_client.client.connect.call_count == 1
-    mock_streaming_client.client.send_binary.assert_any_call(0)
-    mock_streaming_client.client.send_binary.assert_any_call(1)
-    mock_streaming_client.client.send_binary.assert_any_call(2)
-    assert hasattr(mock_streaming_client, 'request_thread')

--- a/tests/test_streamingclient.py
+++ b/tests/test_streamingclient.py
@@ -80,12 +80,12 @@ class TestStreamingClient():
             assert exp_responses[ind + 1] == response
         assert capsys.readouterr().out == exp_responses[2]
 
-    @pytest.mark.parametrize("metadata", [None, "my metadata"])
-    @pytest.mark.parametrize("custom_vocabulary_id", [None, "customvocabid"])
-    @pytest.mark.parametrize("filter_profanity", [None, True])
-    @pytest.mark.parametrize("remove_disfluencies", [None, True])
-    @pytest.mark.parametrize("delete_after_seconds", [None, 0])
-    @pytest.mark.parametrize("detailed_partials", [None, True])
+    @pytest.mark.parametrize("metadata", ["my metadata"])
+    @pytest.mark.parametrize("custom_vocabulary_id", ["customvocabid"])
+    @pytest.mark.parametrize("filter_profanity", [True])
+    @pytest.mark.parametrize("remove_disfluencies", [True])
+    @pytest.mark.parametrize("delete_after_seconds", [0])
+    @pytest.mark.parametrize("detailed_partials", [True])
     def test_start_allparams_success(self, mock_streaming_client, mock_generator, capsys,
         metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials):
 
@@ -132,7 +132,6 @@ class TestStreamingClient():
         mock_streaming_client.end()
 
         mock_streaming_client.client.abort.assert_called_once_with()
-
 
 def build_expected_query_dict(mock_streaming_client, 
     metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials):

--- a/tests/test_streamingclient.py
+++ b/tests/test_streamingclient.py
@@ -59,6 +59,8 @@ class TestStreamingClient():
         filter_profanity = 'true'
         remove_disfluencies = 'true'
         delete_after_seconds = '0'
+        detailed_partials = 'true'
+
         expected_query_dict = {
             'access_token': mock_streaming_client.access_token,
             'content_type': mock_streaming_client.config.get_content_type_string(),
@@ -67,7 +69,8 @@ class TestStreamingClient():
             'metadata': metadata,
             'filter_profanity': filter_profanity,
             'remove_disfluencies': remove_disfluencies,
-            'delete_after_seconds': delete_after_seconds
+            'delete_after_seconds': delete_after_seconds,
+            'detailed_partials': detailed_partials
         }
         example_data = '{"type":"partial","transcript":"Test"}'
         example_connected = '{"type":"connected","id":"testid"}'
@@ -83,7 +86,7 @@ class TestStreamingClient():
         mock_streaming_client.client.recv_data.side_effect = data
 
         response_gen = mock_streaming_client.start(mock_generator(), metadata,
-                                                   custom_vocabulary_id, True, True, 0)
+                                                   custom_vocabulary_id, True, True, 0, True)
 
         assert mock_streaming_client.client.connect.call_count == 1
         called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]

--- a/tests/test_streamingclient.py
+++ b/tests/test_streamingclient.py
@@ -53,25 +53,10 @@ class TestStreamingClient():
         with pytest.raises(ValueError):
             RevAiStreamingClient(None, example_config)
 
-    def test_start_success(self, mock_streaming_client, mock_generator, capsys):
-        custom_vocabulary_id = 'mycustomvocabid'
-        metadata = "my metadata"
-        filter_profanity = 'true'
-        remove_disfluencies = 'true'
-        delete_after_seconds = '0'
-        detailed_partials = 'true'
 
-        expected_query_dict = {
-            'access_token': mock_streaming_client.access_token,
-            'content_type': mock_streaming_client.config.get_content_type_string(),
-            'user_agent': 'RevAi-PythonSDK/{}'.format(__version__),
-            'custom_vocabulary_id': custom_vocabulary_id,
-            'metadata': metadata,
-            'filter_profanity': filter_profanity,
-            'remove_disfluencies': remove_disfluencies,
-            'delete_after_seconds': delete_after_seconds,
-            'detailed_partials': detailed_partials
-        }
+    def test_start_noparams_success(self, mock_streaming_client, mock_generator, capsys):
+        expected_query_dict = build_expected_query_dict(mock_streaming_client, None, None, None, None, None, None)
+
         example_data = '{"type":"partial","transcript":"Test"}'
         example_connected = '{"type":"connected","id":"testid"}'
         if six.PY3:
@@ -85,16 +70,53 @@ class TestStreamingClient():
                          'Connection Closed. Code : 1000; Reason : End of input. Closing\n']
         mock_streaming_client.client.recv_data.side_effect = data
 
-        response_gen = mock_streaming_client.start(mock_generator(), metadata,
-                                                   custom_vocabulary_id, True, True, 0, True)
+        response_gen = mock_streaming_client.start(mock_generator())
 
-        assert mock_streaming_client.client.connect.call_count == 1
         called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]
         validate_query_parameters(called_url, expected_query_dict)
-        mock_streaming_client.client.send_binary.assert_any_call(0)
-        mock_streaming_client.client.send_binary.assert_any_call(1)
-        mock_streaming_client.client.send_binary.assert_any_call(2)
-        assert hasattr(mock_streaming_client, 'request_thread')
+        validate_stream_client(mock_streaming_client)
+        for ind, response in enumerate(response_gen):
+            assert capsys.readouterr().out == exp_responses[ind]
+            assert exp_responses[ind + 1] == response
+        assert capsys.readouterr().out == exp_responses[2]
+
+    @pytest.mark.parametrize("metadata", [None, "my metadata"])
+    @pytest.mark.parametrize("custom_vocabulary_id", [None, "customvocabid"])
+    @pytest.mark.parametrize("filter_profanity", [None, True])
+    @pytest.mark.parametrize("remove_disfluencies", [None, True])
+    @pytest.mark.parametrize("delete_after_seconds", [None, 0])
+    @pytest.mark.parametrize("detailed_partials", [None, True])
+    def test_start_allparams_success(self, mock_streaming_client, mock_generator, capsys,
+        metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials):
+
+        expected_query_dict = build_expected_query_dict(
+            mock_streaming_client,
+            metadata, 
+            custom_vocabulary_id, 
+            filter_profanity, 
+            remove_disfluencies, 
+            delete_after_seconds, 
+            detailed_partials
+        )
+        example_data = '{"type":"partial","transcript":"Test"}'
+        example_connected = '{"type":"connected","id":"testid"}'
+        if six.PY3:
+            example_data = example_data.encode('utf-8')
+            example_connected = example_connected.encode('utf-8')
+        data = [[0x1, example_connected],
+                [0x1, example_data],
+                [0x8, b'\x03\xe8End of input. Closing']]
+        exp_responses = ['Connected, Job ID : testid\n',
+                         '{"type":"partial","transcript":"Test"}',
+                         'Connection Closed. Code : 1000; Reason : End of input. Closing\n']
+        mock_streaming_client.client.recv_data.side_effect = data
+
+        response_gen = mock_streaming_client.start(mock_generator(), 
+            metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials)
+
+        called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]
+        validate_query_parameters(called_url, expected_query_dict)
+        validate_stream_client(mock_streaming_client)
         for ind, response in enumerate(response_gen):
             assert capsys.readouterr().out == exp_responses[ind]
             assert exp_responses[ind + 1] == response
@@ -112,8 +134,38 @@ class TestStreamingClient():
         mock_streaming_client.client.abort.assert_called_once_with()
 
 
+def build_expected_query_dict(mock_streaming_client, 
+    metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials):
+    expected_query_dict = {
+        'access_token': mock_streaming_client.access_token,
+        'content_type': mock_streaming_client.config.get_content_type_string(),
+        'user_agent': 'RevAi-PythonSDK/{}'.format(__version__),
+    }
+
+    if metadata:
+        expected_query_dict["metadata"] = metadata
+    if custom_vocabulary_id:
+        expected_query_dict["custom_vocabulary_id"] = custom_vocabulary_id
+    if filter_profanity:
+        expected_query_dict["filter_profanity"] = "true"
+    if remove_disfluencies:
+        expected_query_dict["remove_disfluencies"] = "true"
+    if delete_after_seconds:
+        expected_query_dict["delete_after_seconds"] = str(delete_after_seconds)   
+    if detailed_partials:
+        expected_query_dict["detailed_partials"] = "true"  
+
+    return expected_query_dict
+
 def validate_query_parameters(called_url, expected_query_dict):
     called_query_string = urlparse(called_url).query
     called_query_parameters = parse_qs(called_query_string)
     for key in expected_query_dict:
         assert called_query_parameters[key][0] == expected_query_dict[key]
+
+def validate_stream_client(mock_streaming_client):
+    assert mock_streaming_client.client.connect.call_count == 1
+    mock_streaming_client.client.send_binary.assert_any_call(0)
+    mock_streaming_client.client.send_binary.assert_any_call(1)
+    mock_streaming_client.client.send_binary.assert_any_call(2)
+    assert hasattr(mock_streaming_client, 'request_thread')


### PR DESCRIPTION
In documentation we have `detailed_partials` parameter, which is in beta, but should be available in SDK:
https://www.rev.ai/docs/streaming#section/WebSocket-Endpoint/Detailed-Partials-(Beta)