### PR TITLE
AISDK-135: Switch from Travis CI to Github Actions; update dev dependencies and tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.5', '3.6']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: local-fix
+      run: |
+        # Hack to get setup-python to work on act
+        # (see https://github.com/nektos/act/issues/251)
+        if [ ! -f "/etc/lsb-release" ] ; then
+          echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
+        fi
+    - name: Set Up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements.txt -r requirements_dev.txt
+    - name: Test
+      run: python setup.py test
+    - name: Lint
+      run: |
+        flake8 rev_ai tests --ignore=F401,W504,E731,E123,E125,E127,E128,E501
+        flake8 rev_ai src --ignore=F401,W504

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -41,5 +41,5 @@ jobs:
       run: python setup.py test
     - name: Lint
       run: |
-        flake8 rev_ai tests --ignore=F401,W504,E731,E123,E125,E127,E128,E501
-        flake8 rev_ai src --ignore=F401,W504
+        flake8 tests --ignore=F401,W504,E731,E123,E125,E127,E128,E501
+        flake8 src --ignore=F401,W504

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -78,3 +78,8 @@ History
 ------------------
 
 * Add custom_vocabulary_id to async client
+
+2.13.0
+------------------
+* Add detailed_partials to streaming client
+* Switch to Github Actions for automated testing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rev.ai Python SDK
 
-[![Build Status](https://travis-ci.org/revdotcom/revai-python-sdk.svg?branch=develop)](https://travis-ci.org/revdotcom/revai-python-sdk)
+[![CI](https://github.com/revdotcom/revai-python-sdk/actions/workflows/build_test.yml/badge.svg)](https://github.com/revdotcom/revai-python-sdk/actions/workflows/build_test.yml)
 
 ## Documentation
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,7 @@
-pytest==6.2.5
+pytest==4.6.5;python_version<"3.6"
+pytest==6.2.5;python_version>="3.6"
 pytest-cov==2.6.1
 pytest-mock==1.10.0
-flake8==4.0.0
+flake8==3.6.0;python_version<"3.6"
+flake8==4.0.0;python_version>="3.6"
 mock==3.0.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
-pytest==4.6.5
+pytest==6.2.5
 pytest-cov==2.6.1
 pytest-mock==1.10.0
-flake8==3.6.0
+flake8==4.0.0
 mock==3.0.5

--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -77,7 +77,7 @@ class RevAiStreamingClient():
         :param filter_profanity: whether to mask profane words
         :param remove_disfluencies: whether to exclude filler words like "uh"
         :param delete_after_seconds: number of seconds after job completion when job is auto-deleted
-        :param detailed_partials: whether to receive timestamps and confidence scores 
+        :param detailed_partials: whether to receive timestamps and confidence scores
         """
         url = self.base_url + '?' + urlencode({
             'access_token': self.access_token,
@@ -99,7 +99,7 @@ class RevAiStreamingClient():
 
         if delete_after_seconds is not None:
             url += '&' + urlencode({'delete_after_seconds': delete_after_seconds})
-            
+
         if detailed_partials:
             url += '&' + urlencode({'detailed_partials': 'true'})
 

--- a/tests/test_streamingclient.py
+++ b/tests/test_streamingclient.py
@@ -53,7 +53,6 @@ class TestStreamingClient():
         with pytest.raises(ValueError):
             RevAiStreamingClient(None, example_config)
 
-
     def test_start_noparams_success(self, mock_streaming_client, mock_generator, capsys):
         expected_query_dict = build_expected_query_dict(mock_streaming_client, None, None, None, None, None, None)
 
@@ -95,11 +94,11 @@ class TestStreamingClient():
 
         expected_query_dict = build_expected_query_dict(
             mock_streaming_client,
-            metadata, 
-            custom_vocabulary_id, 
-            filter_profanity, 
-            remove_disfluencies, 
-            delete_after_seconds, 
+            metadata,
+            custom_vocabulary_id,
+            filter_profanity,
+            remove_disfluencies,
+            delete_after_seconds,
             detailed_partials
         )
         example_data = '{"type":"partial","transcript":"Test"}'
@@ -115,7 +114,7 @@ class TestStreamingClient():
                          'Connection Closed. Code : 1000; Reason : End of input. Closing\n']
         mock_streaming_client.client.recv_data.side_effect = data
 
-        response_gen = mock_streaming_client.start(mock_generator(), 
+        response_gen = mock_streaming_client.start(mock_generator(),
             metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials)
 
         called_url = mock_streaming_client.client.connect.call_args_list[0][0][0]
@@ -141,7 +140,8 @@ class TestStreamingClient():
 
         mock_streaming_client.client.abort.assert_called_once_with()
 
-def build_expected_query_dict(mock_streaming_client, 
+
+def build_expected_query_dict(mock_streaming_client,
     metadata, custom_vocabulary_id, filter_profanity, remove_disfluencies, delete_after_seconds, detailed_partials):
     expected_query_dict = {
         'access_token': mock_streaming_client.access_token,
@@ -158,11 +158,12 @@ def build_expected_query_dict(mock_streaming_client,
     if remove_disfluencies:
         expected_query_dict["remove_disfluencies"] = "true"
     if delete_after_seconds:
-        expected_query_dict["delete_after_seconds"] = str(delete_after_seconds)   
+        expected_query_dict["delete_after_seconds"] = str(delete_after_seconds)
     if detailed_partials:
-        expected_query_dict["detailed_partials"] = "true"  
+        expected_query_dict["detailed_partials"] = "true"
 
     return expected_query_dict
+
 
 def validate_query_parameters(called_url, expected_query_dict):
     called_query_string = urlparse(called_url).query


### PR DESCRIPTION
The Travis CI integration stopped working when Travis changed their business model. Our internal tests continued to function properly, but it is better to have a public facing test suite which developers can view to see that the SDK is actively being maintained.