### PR TITLE
AISDK-175: Update Python SDK with Rev.ai to Rev AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rev.ai Python SDK
+# Rev AI Python SDK
 
 [![CI](https://github.com/revdotcom/revai-python-sdk/actions/workflows/build_test.yml/badge.svg)](https://github.com/revdotcom/revai-python-sdk/actions/workflows/build_test.yml)
 
@@ -226,7 +226,7 @@ client.delete_custom_vocabulary(custom_vocabularies_job['id'])
 
 For more details, check out the custom vocabularies example in our [examples](https://github.com/revdotcom/revai-python-sdk/tree/develop/examples).
 
-# For Rev.ai Python SDK Developers
+# For Rev AI Python SDK Developers
 
 Remember in your development to follow the PEP8 style guide. Your code editor likely has Python PEP8 linting packages which can assist you in your development.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('requirements_dev.txt', 'r') as req_dev_file:
 setup(
     name='rev_ai',
     version=version,
-    description='Rev.ai makes speech applications easy to build!',
+    description='Rev AI makes speech applications easy to build!',
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/markdown',
     author="Rev Ai",

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Speech recognition tools for using Rev.ai"""
+"""Speech recognition tools for using Rev AI"""
 
 import json
 from .models import Account, CaptionType, Job, Transcript
@@ -13,7 +13,7 @@ except ImportError:
 
 
 class RevAiAPIClient(BaseClient):
-    """Client which implements Rev.ai API
+    """Client which implements Rev AI API
 
     Note that HTTPErrors can be thrown by methods of the API client. The HTTP
     response payload attached to these error is a problem details. The problem
@@ -23,7 +23,7 @@ class RevAiAPIClient(BaseClient):
     Problem details are defined at https://tools.ietf.org/html/rfc7807.
     """
 
-    # Rev.ai transcript format
+    # Rev AI transcript format
     rev_json_content_type = 'application/vnd.rev.transcript.v1.0+json'
 
     def __init__(self, access_token):
@@ -31,7 +31,7 @@ class RevAiAPIClient(BaseClient):
 
         :param access_token: access token which authorizes all requests and links them to your
                              account. Generated on the settings page of your account dashboard
-                             on Rev.ai.
+                             on Rev AI.
         """
 
         BaseClient.__init__(self, access_token)

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -62,9 +62,9 @@ class RevAiAPIClient(BaseClient):
         :param metadata: info to associate with the transcription job
         :param callback_url: callback url to invoke on job completion as
                              a webhook
-        :param skip_diarization: should rev.ai skip diaization when
+        :param skip_diarization: should Rev AI skip diaization when
                                  transcribing this file
-        :param skip_punctuation: should rev.ai skip punctuation when
+        :param skip_punctuation: should Rev AI skip punctuation when
                                  transcribing this file
         :param speaker_channels_count: the number of speaker channels in the
             audio. If provided the given audio will have each channel
@@ -141,9 +141,9 @@ class RevAiAPIClient(BaseClient):
         :param metadata: info to associate with the transcription job
         :param callback_url: callback url to invoke on job completion as a
                              webhook
-        :param skip_diarization: should rev.ai skip diaization when
+        :param skip_diarization: should Rev AI skip diaization when
                                  transcribing this file
-        :param skip_punctuation: should rev.ai skip punctuation when
+        :param skip_punctuation: should Rev AI skip punctuation when
                                  transcribing this file
         :param speaker_channels_count: the number of speaker channels in the
             audio. If provided the given audio will have each channel

--- a/src/rev_ai/baseclient.py
+++ b/src/rev_ai/baseclient.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Speech recognition tools for using Rev.ai"""
+"""Speech recognition tools for using Rev AI"""
 
 import requests
 from requests.exceptions import HTTPError
@@ -10,7 +10,7 @@ from . import CustomVocabulary
 class BaseClient:
     """Base for clients that communicate with RevAI Apis"""
 
-    # Default version of Rev.ai
+    # Default version of Rev AI
     version = 'v1'
 
     # Default address of the API
@@ -22,7 +22,7 @@ class BaseClient:
         :param access_token: access token which authorizes all requests and
                              links them to your account. Generated on the
                              settings page of your account dashboard
-                             on Rev.ai
+                             on Rev AI
         """
         if not access_token:
             raise ValueError('access_token must be provided')

--- a/src/rev_ai/custom_vocabularies_client.py
+++ b/src/rev_ai/custom_vocabularies_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Speech recognition tools for using Rev.ai"""
+"""Speech recognition tools for using Rev AI"""
 
 from .baseclient import BaseClient
 from . import utils
@@ -11,7 +11,7 @@ except ImportError:
 
 
 class RevAiCustomVocabulariesClient(BaseClient):
-    """Client which implements Rev.ai CustomVocabulary API
+    """Client which implements Rev AI CustomVocabulary API
     See https://docs.rev.ai/api/custom-vocabulary/reference/
     """
 
@@ -21,7 +21,7 @@ class RevAiCustomVocabulariesClient(BaseClient):
         :param access_token: access token which authorizes all requests and
                              links them to your account. Generated on the
                              settings page of your account dashboard
-                             on Rev.ai
+                             on Rev AI
         """
         BaseClient.__init__(self, access_token)
 

--- a/src/rev_ai/streamingclient.py
+++ b/src/rev_ai/streamingclient.py
@@ -35,7 +35,7 @@ class RevAiStreamingClient():
         """Constructor for Streaming Client
         :param access_token: access token which authorizes all requests and
             links them to your account. Generated on the settings page of your
-            account dashboard on Rev.ai.
+            account dashboard on Rev AI.
         :param config: a MediaConfig object containing audio information.
             See MediaConfig.py for more information
         :param version (optional): version of the streaming api to be used

--- a/src/rev_ai/utils.py
+++ b/src/rev_ai/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Speech recognition tools for using Rev.ai"""
+"""Speech recognition tools for using Rev AI"""
 
 from . import CustomVocabulary
 


### PR DESCRIPTION
One question I had about this [line](https://github.com/revdotcom/revai-python-sdk/blob/83b67b6474ac0a2aea2bb13680e0afede19d6d63/src/rev_ai/apiclient.py#L65) (there are four similar lines like this in this file) with it being lower case and the context sounds more like it was specific to the url rev.ai and not the over all brand Rev AI. I may be reading wrong just needed clarification if this line and the others similar in the file should be changed.