### PR TITLE
AISDK-221 Fix HIPAA Error Message on Incorrect Usage

### DIFF
--- a/tests/helpers/errors.py
+++ b/tests/helpers/errors.py
@@ -7,6 +7,10 @@ ERRORS = {
         "title": "Authorization has been denied for this request",
         "status": 401
     },
+    'forbidden': {
+        "status": 403,
+        "error": "HIPAA user is not allowed to use MediaUrl"
+    },
     'job-not-found': {
         "type": "https://www.rev.ai/api/v1/errors/job-not-found",
         "title": "could not find job",

--- a/tests/helpers/errors.py
+++ b/tests/helpers/errors.py
@@ -14,7 +14,7 @@ ERRORS = {
     },
     'forbidden': {
         "status": 403,
-        "error": "HIPAA user is not allowed to use MediaUrl"
+        "error": "The client is forbidden to submit that request"
     },
     'job-not-found': {
         "type": "https://www.rev.ai/api/v1/errors/job-not-found",

--- a/tests/helpers/errors.py
+++ b/tests/helpers/errors.py
@@ -3,6 +3,11 @@ def get_error_test_cases(errors):
 
 
 ERRORS = {
+    'invalid-parameters': {
+        "type": "https://www.rev.ai/api/v1/errors/invalid-parameters",
+        "title": "Your request parameters did not validate",
+        "status": 400
+    },
     'unauthorized': {
         "title": "Authorization has been denied for this request",
         "status": 401

--- a/tests/helpers/errors.py
+++ b/tests/helpers/errors.py
@@ -3,16 +3,6 @@ def get_error_test_cases(errors):
 
 
 ERRORS = {
-    'invalid-parameters': {
-        "parameter": {
-            "example": [
-                "The example field is required"
-            ]
-        },
-        "type": "https://www.rev.ai/api/v1/errors/invalid-parameters",
-        "title": "Your request parameters didn't validate",
-        "status": 400
-    },
     'unauthorized': {
         "title": "Authorization has been denied for this request",
         "status": 401
@@ -21,13 +11,6 @@ ERRORS = {
         "type": "https://www.rev.ai/api/v1/errors/job-not-found",
         "title": "could not find job",
         "status": 404
-    },
-    'out-of-credit': {
-        "title": "You do not have enough credits",
-        "type": "https://www.rev.ai/api/v1/errors/out-of-credit",
-        "detail": "You have only 60 seconds remaining",
-        "current_balance": 60,
-        "status": 403
     },
     'invalid-job-state': {
         "allowed_values": [

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -29,7 +29,7 @@ class TestBaseClient:
             RevAiAPIClient(token)
 
     @pytest.mark.parametrize('error', get_error_test_cases(
-        ['unauthorized', 'forbidden', 'job-not-found', 'invalid-job-state']))
+        ['invalid-parameters', 'unauthorized', 'forbidden', 'job-not-found', 'invalid-job-state']))
     @pytest.mark.parametrize('method', ["POST", "GET", "DELETE"])
     def test_make_http_request(self, error, method, mock_session,
                                make_mock_response):

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -29,7 +29,7 @@ class TestBaseClient:
             RevAiAPIClient(token)
 
     @pytest.mark.parametrize('error', get_error_test_cases(
-        ['unauthorized', 'job-not-found', 'invalid-job-state']))
+        ['unauthorized', 'forbidden', 'job-not-found', 'invalid-job-state']))
     @pytest.mark.parametrize('method', ["POST", "GET", "DELETE"])
     def test_make_http_request(self, error, method, mock_session,
                                make_mock_response):


### PR DESCRIPTION
The python sdk does not try to wrap any of the http error responses from the API, so no need to fix handling of a 403 here. This PR just removes some unnecessary test entries.