### PR TITLE
REVAI-3918 Split NlpModel to have separate enums for Translation and Summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ job = client.submit_job_url("https://example.com/file-to-transcribe.mp3",
     language='en',
     translation_config=TranslationOptions(
         target_languages: [
-            TranslationLanguageOptions("es", NlpModel.PREMIUM),
+            TranslationLanguageOptions("es", TranslationModel.PREMIUM),
             TranslationLanguageOptions("de")
         ]
     ));

--- a/examples/async_summarize.py
+++ b/examples/async_summarize.py
@@ -31,7 +31,7 @@ client = apiclient.RevAiAPIClient(access_token)
 #                                    delete_after_seconds=2592000,
 #                                    language='en',
 #                                    summarization_config=SummarizationOptions(
-#                                        model=NlpModel.PREMIUM
+#                                        model=SummarizationModel.PREMIUM
 #                                    ))
 
 
@@ -41,7 +41,7 @@ url = "https://www.rev.ai/FTC_Sample_1.mp3"
 job = client.submit_job_url(media_url=url,
                             delete_after_seconds=2592000,
                             language='en',
-                            summarization_config=SummarizationOptions(model=NlpModel.PREMIUM))
+                            summarization_config=SummarizationOptions(model=SummarizationModel.PREMIUM))
 
 print("Submitted Job")
 print("Job Status : {}".format(job.status))

--- a/examples/async_translate.py
+++ b/examples/async_translate.py
@@ -18,7 +18,7 @@ from rev_ai import apiclient, JobStatus
 from rev_ai.models.asynchronous.translation_job_status import TranslationJobStatus
 from rev_ai.models.asynchronous.translation_language_options import TranslationLanguageOptions
 from rev_ai.models.asynchronous.translation_options import TranslationOptions
-from rev_ai.models.nlp_model import NlpModel
+from rev_ai.models.asynchronous.translation_model import TranslationModel
 
 # String containing your access token
 access_token = "<your_access_token>"
@@ -33,7 +33,7 @@ client = apiclient.RevAiAPIClient(access_token)
 #                             language='en',
 #                             translation_config=TranslationOptions(
 #                                 target_languages=[
-#                                     TranslationLanguageOptions("es", NlpModel.PREMIUM)
+#                                     TranslationLanguageOptions("es", TranslationModel.PREMIUM)
 #                                 ]
 #                             ))
 
@@ -45,7 +45,7 @@ job = client.submit_job_url(media_url=url,
                             language='en',
                             translation_config=TranslationOptions(
                                 target_languages=[
-                                    TranslationLanguageOptions("es", NlpModel.PREMIUM)
+                                    TranslationLanguageOptions("es", TranslationModel.PREMIUM)
                                 ]
                             ))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.19.0
+current_version = 2.19.1
 commit = True
 tag = True
 

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Top-level package for rev_ai"""
 
-__version__ = '2.19.1'
+__version__ = '2.19.2'
 
 from .models import Job, JobStatus, Account, Transcript, Monologue, Element, MediaConfig, \
     CaptionType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, Topic, Informant, \

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -413,23 +413,21 @@ class RevAiAPIClient(BaseClient):
 
         return response.text
 
-    def get_translated_captions(self, id_, language, content_type=CaptionType.SRT, channel_id=None):
+    def get_translated_captions(self, id_, language, content_type=CaptionType.SRT):
         """Get the captions output of a specific job and return it as plain text
 
         :param id_: id of job to be requested
         :param content_type: caption type which should be returned. Defaults to SRT
-        :param channel_id: id of speaker channel to be captioned, only matters for multichannel jobs
         :returns: caption data as text
         :raises: HTTPError
         """
         if not id_:
             raise ValueError('id_ must be provided')
-        query = self._create_captions_query(channel_id)
 
         response = self._make_http_request(
             "GET",
             urljoin(self.base_url,
-                    'jobs/{0}/captions/translation/{1}{2}'.format(id_, language, query)),
+                    'jobs/{0}/captions/translation/{1}'.format(id_, language)),
             headers={'Accept': content_type.value}
         )
 

--- a/src/rev_ai/models/asynchronous/summarization_model.py
+++ b/src/rev_ai/models/asynchronous/summarization_model.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class SummarizationModel(str, Enum):
+    STANDARD = "standard"
+    PREMIUM = "premium"

--- a/src/rev_ai/models/asynchronous/summarization_options.py
+++ b/src/rev_ai/models/asynchronous/summarization_options.py
@@ -1,6 +1,6 @@
 from .summarization_formatting_options import SummarizationFormattingOptions
 from .summarization_job_status import SummarizationJobStatus
-from ..nlp_model import NlpModel
+from .summarization_model import SummarizationModel
 
 
 class SummarizationOptions:
@@ -9,7 +9,7 @@ class SummarizationOptions:
     def __init__(
             self,
             prompt: str = None,
-            model: NlpModel = None,
+            model: SummarizationModel = None,
             formatting_type: SummarizationFormattingOptions = None):
         self.prompt = prompt
         self.model = model
@@ -35,7 +35,7 @@ class Summarization(SummarizationOptions):
     def __init__(
             self,
             prompt: str = None,
-            model: NlpModel = None,
+            model: SummarizationModel = None,
             formatting_type: SummarizationFormattingOptions = None,
             status: SummarizationJobStatus = None,
             completed_on: str = None,

--- a/src/rev_ai/models/asynchronous/translation_language_options.py
+++ b/src/rev_ai/models/asynchronous/translation_language_options.py
@@ -1,5 +1,5 @@
 from .translation_job_status import TranslationJobStatus
-from ..nlp_model import NlpModel
+from .translation_model import TranslationModel
 
 
 class TranslationLanguageOptions:
@@ -7,7 +7,7 @@ class TranslationLanguageOptions:
     def __init__(
             self,
             language: str = None,
-            model: NlpModel = None):
+            model: TranslationModel = None):
         self.language = language
         self.model = model
 
@@ -28,7 +28,7 @@ class TranslationLanguage(TranslationLanguageOptions):
     def __init__(
             self,
             language: str = None,
-            model: NlpModel = None,
+            model: TranslationModel = None,
             status: TranslationJobStatus = None,
             failure: str = None):
         super().__init__(language, model)

--- a/src/rev_ai/models/asynchronous/translation_model.py
+++ b/src/rev_ai/models/asynchronous/translation_model.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
 
-class NlpModel(str, Enum):
+class TranslationModel(str, Enum):
     STANDARD = "standard"
     PREMIUM = "premium"

--- a/tests/test_async_captions_translation.py
+++ b/tests/test_async_captions_translation.py
@@ -1,16 +1,6 @@
-import json
-
 import pytest
 
-from src.rev_ai import JobStatus
 from src.rev_ai.apiclient import RevAiAPIClient
-from src.rev_ai.models.asynchronous.summarization_formatting_options import SummarizationFormattingOptions
-from src.rev_ai.models.asynchronous.summarization_job_status import SummarizationJobStatus
-from src.rev_ai.models.asynchronous.summarization_options import SummarizationOptions
-from src.rev_ai.models.asynchronous.translation_job_status import TranslationJobStatus
-from src.rev_ai.models.asynchronous.translation_language_options import TranslationLanguageOptions
-from src.rev_ai.models.asynchronous.translation_options import TranslationOptions
-from src.rev_ai.models.nlp_model import NlpModel
 
 try:
     from urllib.parse import urljoin

--- a/tests/test_async_summarization.py
+++ b/tests/test_async_summarization.py
@@ -6,7 +6,7 @@ from src.rev_ai.apiclient import RevAiAPIClient
 from src.rev_ai.models.asynchronous.summarization_formatting_options import SummarizationFormattingOptions
 from src.rev_ai.models.asynchronous.summarization_job_status import SummarizationJobStatus
 from src.rev_ai.models.asynchronous.summarization_options import SummarizationOptions
-from src.rev_ai.models.nlp_model import NlpModel
+from src.rev_ai.models.asynchronous.summarization_model import SummarizationModel
 
 try:
     from urllib.parse import urljoin
@@ -48,7 +48,7 @@ class TestAsyncSummarization():
                                                language="en",
                                                summarization_config=SummarizationOptions(
                                                    prompt="Try to summarize this transcript as good as you possibly can",
-                                                   model=NlpModel.PREMIUM,
+                                                   model=SummarizationModel.PREMIUM,
                                                    formatting_type=SummarizationFormattingOptions.BULLETS
 
                                                ))
@@ -73,7 +73,7 @@ class TestAsyncSummarization():
         )
 
         assert job.summarization is not None
-        assert job.summarization.model == NlpModel.PREMIUM
+        assert job.summarization.model == SummarizationModel.PREMIUM
         assert job.summarization.type == SummarizationFormattingOptions.BULLETS
         assert job.summarization.prompt == "Try to summarize this transcript as good as you possibly can"
 
@@ -102,7 +102,7 @@ class TestAsyncSummarization():
                                     language="en",
                                     summarization_config=SummarizationOptions(
                                         "Try to summarize this transcript as good as you possibly can",
-                                        NlpModel.PREMIUM,
+                                        SummarizationModel.PREMIUM,
                                         SummarizationFormattingOptions.BULLETS
 
                                     ))
@@ -123,7 +123,7 @@ class TestAsyncSummarization():
 
         assert job.summarization is not None
         assert job.summarization.status == SummarizationJobStatus.COMPLETED
-        assert job.summarization.model == NlpModel.PREMIUM
+        assert job.summarization.model == SummarizationModel.PREMIUM
         assert job.summarization.type == SummarizationFormattingOptions.BULLETS
         assert job.summarization.prompt == "Try to summarize this transcript as good as you possibly can"
 

--- a/tests/test_async_translation.py
+++ b/tests/test_async_translation.py
@@ -2,15 +2,11 @@ import json
 
 import pytest
 
-from src.rev_ai import JobStatus
 from src.rev_ai.apiclient import RevAiAPIClient
-from src.rev_ai.models.asynchronous.summarization_formatting_options import SummarizationFormattingOptions
-from src.rev_ai.models.asynchronous.summarization_job_status import SummarizationJobStatus
-from src.rev_ai.models.asynchronous.summarization_options import SummarizationOptions
 from src.rev_ai.models.asynchronous.translation_job_status import TranslationJobStatus
 from src.rev_ai.models.asynchronous.translation_language_options import TranslationLanguageOptions
 from src.rev_ai.models.asynchronous.translation_options import TranslationOptions
-from src.rev_ai.models.nlp_model import NlpModel
+from src.rev_ai.models.asynchronous.translation_model import TranslationModel
 
 try:
     from urllib.parse import urljoin
@@ -59,7 +55,7 @@ class TestAsyncTranslation():
                                                language="en",
                                                translation_config=TranslationOptions(
                                                    target_languages=[
-                                                       TranslationLanguageOptions("es", NlpModel.PREMIUM),
+                                                       TranslationLanguageOptions("es", TranslationModel.PREMIUM),
                                                        TranslationLanguageOptions("ru")
                                                    ]
                                                ))
@@ -95,7 +91,7 @@ class TestAsyncTranslation():
         assert job.translation.completed_on is not None
         assert job.translation.target_languages[0].status == TranslationJobStatus.COMPLETED
         assert job.translation.target_languages[0].language == "es"
-        assert job.translation.target_languages[0].model == NlpModel.PREMIUM
+        assert job.translation.target_languages[0].model == TranslationModel.PREMIUM
 
         assert job.translation.target_languages[1].status, TranslationJobStatus.COMPLETED
         assert job.translation.target_languages[1].language, "ru"
@@ -140,7 +136,7 @@ class TestAsyncTranslation():
                                     language="en",
                                     translation_config=TranslationOptions(
                                         target_languages=[
-                                            TranslationLanguageOptions("es", NlpModel.PREMIUM),
+                                            TranslationLanguageOptions("es", TranslationModel.PREMIUM),
                                             TranslationLanguageOptions("ru")
                                         ]
                                     )
@@ -172,7 +168,7 @@ class TestAsyncTranslation():
         assert job.translation.completed_on is not None
         assert job.translation.target_languages[0].status == TranslationJobStatus.COMPLETED
         assert job.translation.target_languages[0].language == "es"
-        assert job.translation.target_languages[0].model == NlpModel.PREMIUM
+        assert job.translation.target_languages[0].model == TranslationModel.PREMIUM
 
         assert job.translation.target_languages[1].status, TranslationJobStatus.COMPLETED
         assert job.translation.target_languages[1].language, "ru"


### PR DESCRIPTION
REVAI-3918: Split NlpModel to have separate enums for Translation and Summarization
https://revinc.atlassian.net/browse/REVAI-3918
