### PR TITLE
REVAI-4324: Multichannel transcript grouping

### DIFF
--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Top-level package for rev_ai"""
 
-__version__ = '2.20.0'
+__version__ = '2.21.0'
 
 from .models import Job, JobStatus, Account, Transcript, Monologue, Element, MediaConfig, \
     CaptionType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, Topic, Informant, \

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -4,7 +4,7 @@
 __version__ = '2.21.0'
 
 from .models import Job, JobStatus, Account, Transcript, Monologue, Element, MediaConfig, \
-    CaptionType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, Topic, Informant, \
+    CaptionType, GroupChannelsType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, Topic, Informant, \
     SpeakerName, LanguageIdentificationJob, LanguageIdentificationResult, LanguageConfidence, \
     SentimentAnalysisResult, SentimentValue, SentimentMessage, SentimentAnalysisJob, \
     CustomerUrlData, RevAiApiDeploymentConfigMap, RevAiApiDeployment

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -4,7 +4,7 @@
 __version__ = '2.21.0'
 
 from .models import Job, JobStatus, Account, Transcript, Monologue, Element, MediaConfig, \
-    CaptionType, GroupChannelsType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, Topic, Informant, \
-    SpeakerName, LanguageIdentificationJob, LanguageIdentificationResult, LanguageConfidence, \
-    SentimentAnalysisResult, SentimentValue, SentimentMessage, SentimentAnalysisJob, \
-    CustomerUrlData, RevAiApiDeploymentConfigMap, RevAiApiDeployment
+    CaptionType, GroupChannelsType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, \
+    Topic, Informant, SpeakerName, LanguageIdentificationJob, LanguageIdentificationResult, \
+    LanguageConfidence, SentimentAnalysisResult, SentimentValue, SentimentMessage, \
+    SentimentAnalysisJob, CustomerUrlData, RevAiApiDeploymentConfigMap, RevAiApiDeployment

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -349,9 +349,12 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
         
-        url = self._build_transcript_url(self, id_,
-                                         group_channels_by=group_channels_by,
-                                         group_channels_threshold_ms=group_channels_threshold_ms)
+        url = self._build_transcript_url(
+            self,
+            id_,
+            group_channels_by=group_channels_by,
+            group_channels_threshold_ms=group_channels_threshold_ms
+        )
 
         response = self._make_http_request(
             "GET",
@@ -374,9 +377,12 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
-        url = self._build_transcript_url(self, id_,
-                                         group_channels_by=group_channels_by,
-                                         group_channels_threshold_ms=group_channels_threshold_ms)
+        url = self._build_transcript_url(
+            self,
+            id_,
+            group_channels_by=group_channels_by,
+            group_channels_threshold_ms=group_channels_threshold_ms
+        )
 
         response = self._make_http_request(
             "GET",
@@ -399,9 +405,12 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
-        url = self._build_transcript_url(self, id_,
-                                         group_channels_by=group_channels_by,
-                                         group_channels_threshold_ms=group_channels_threshold_ms)
+        url = self._build_transcript_url(
+            self,
+            id_,
+            group_channels_by=group_channels_by,
+            group_channels_threshold_ms=group_channels_threshold_ms
+        )
 
         response = self._make_http_request(
             "GET",
@@ -424,9 +433,12 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
-        url = self._build_transcript_url(self, id_,
-                                         group_channels_by=group_channels_by,
-                                         group_channels_threshold_ms=group_channels_threshold_ms)
+        url = self._build_transcript_url(
+            self,
+            id_,
+            group_channels_by=group_channels_by,
+            group_channels_threshold_ms=group_channels_threshold_ms
+        )
 
         response = self._make_http_request(
             "GET",
@@ -449,9 +461,12 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
-        url = self._build_transcript_url(self, id_,
-                                         group_channels_by=group_channels_by,
-                                         group_channels_threshold_ms=group_channels_threshold_ms)
+        url = self._build_transcript_url(
+            self,
+            id_,
+            group_channels_by=group_channels_by,
+            group_channels_threshold_ms=group_channels_threshold_ms
+        )
 
         response = self._make_http_request(
             "GET",

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -337,12 +337,14 @@ class RevAiAPIClient(BaseClient):
 
         return [Job.from_json(job) for job in response.json()]
 
-    def get_transcript_text(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
+    def get_transcript_text(self, id_, group_channels_by=None, group_channels_threshold_ms=1000):
         """Get the transcript of a specific job as plain text.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: transcript data as text
         :raises: HTTPError
         """
@@ -370,8 +372,10 @@ class RevAiAPIClient(BaseClient):
         """Get the transcript of a specific job as a plain text stream.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -401,8 +405,10 @@ class RevAiAPIClient(BaseClient):
         """Get the transcript of a specific job as json.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: transcript data as json
         :raises: HTTPError
         """
@@ -430,8 +436,10 @@ class RevAiAPIClient(BaseClient):
         """Get the transcript of a specific job as streamed json.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -458,8 +466,10 @@ class RevAiAPIClient(BaseClient):
         """Get the transcript of a specific job as a python object`.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: transcript data as a python object
         :raises: HTTPError
         """
@@ -868,8 +878,8 @@ class RevAiAPIClient(BaseClient):
         """Build the get transcript url.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
+        :param group_channels_by: optional, None for default, multichannel transcript grouping strategy
+        :param group_channels_threshold_ms: optional, None for default, grouping threshold, milliseconds
         :returns: url for getting the transcript
         """
         params = []

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -363,12 +363,15 @@ class RevAiAPIClient(BaseClient):
 
         return response.text
 
-    def get_transcript_text_as_stream(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
+    def get_transcript_text_as_stream(self,
+                                      id_,
+                                      group_channels_by=None,
+                                      group_channels_threshold_ms=None):
         """Get the transcript of a specific job as a plain text stream.
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -391,12 +394,15 @@ class RevAiAPIClient(BaseClient):
 
         return response
 
-    def get_transcript_json(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
+    def get_transcript_json(self,
+                            id_,
+                            group_channels_by=None,
+                            group_channels_threshold_ms=None):
         """Get the transcript of a specific job as json.
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: transcript data as json
         :raises: HTTPError
         """
@@ -417,12 +423,15 @@ class RevAiAPIClient(BaseClient):
 
         return response.json()
 
-    def get_transcript_json_as_stream(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
+    def get_transcript_json_as_stream(self,
+                                      id_,
+                                      group_channels_by=None,
+                                      group_channels_threshold_ms=None):
         """Get the transcript of a specific job as streamed json.
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -450,7 +459,7 @@ class RevAiAPIClient(BaseClient):
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: transcript data as a python object
         :raises: HTTPError
         """

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -342,7 +342,7 @@ class RevAiAPIClient(BaseClient):
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: transcript data as text
         :raises: HTTPError
         """
@@ -860,7 +860,7 @@ class RevAiAPIClient(BaseClient):
 
         :param id_: id of job to be requested
         :param group_channels_by: optional, group channels by speaker or time
-        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :param group_channels_threshold_ms: optional, group channels by time threshold, ms
         :returns: url for getting the transcript
         """
         params = []

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -337,7 +337,11 @@ class RevAiAPIClient(BaseClient):
 
         return [Job.from_json(job) for job in response.json()]
 
-    def get_transcript_text(self, id_, group_channels_by=None, group_channels_threshold_ms=1000):
+    def get_transcript_text(
+            self,
+            id_,
+            group_channels_by=None,
+            group_channels_threshold_ms=None):
         """Get the transcript of a specific job as plain text.
 
         :param id_: id of job to be requested

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -348,7 +348,7 @@ class RevAiAPIClient(BaseClient):
         """
         if not id_:
             raise ValueError('id_ must be provided')
-        
+
         url = self._build_transcript_url(
             id_,
             group_channels_by=group_channels_by,
@@ -863,7 +863,7 @@ class RevAiAPIClient(BaseClient):
 
     def _create_captions_query(self, speaker_channel):
         return '' if speaker_channel is None else '?speaker_channel={}'.format(speaker_channel)
-    
+
     def _build_transcript_url(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Build the get transcript url.
 

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -337,11 +337,7 @@ class RevAiAPIClient(BaseClient):
 
         return [Job.from_json(job) for job in response.json()]
 
-    def get_transcript_text(
-            self,
-            id_,
-            group_channels_by=None,
-            group_channels_threshold_ms=None):
+    def get_transcript_text(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as plain text.
 
         :param id_: id of job to be requested

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -337,28 +337,36 @@ class RevAiAPIClient(BaseClient):
 
         return [Job.from_json(job) for job in response.json()]
 
-    def get_transcript_text(self, id_):
+    def get_transcript_text(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as plain text.
 
         :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
         :returns: transcript data as text
         :raises: HTTPError
         """
         if not id_:
             raise ValueError('id_ must be provided')
+        
+        url = self._build_transcript_url(self, id_,
+                                         group_channels_by=group_channels_by,
+                                         group_channels_threshold_ms=group_channels_threshold_ms)
 
         response = self._make_http_request(
             "GET",
-            urljoin(self.base_url, 'jobs/{}/transcript'.format(id_)),
+            url,
             headers={'Accept': 'text/plain'}
         )
 
         return response.text
 
-    def get_transcript_text_as_stream(self, id_):
+    def get_transcript_text_as_stream(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as a plain text stream.
 
         :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -366,37 +374,49 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
+        url = self._build_transcript_url(self, id_,
+                                         group_channels_by=group_channels_by,
+                                         group_channels_threshold_ms=group_channels_threshold_ms)
+
         response = self._make_http_request(
             "GET",
-            urljoin(self.base_url, 'jobs/{}/transcript'.format(id_)),
+            url,
             headers={'Accept': 'text/plain'},
             stream=True
         )
 
         return response
 
-    def get_transcript_json(self, id_):
+    def get_transcript_json(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as json.
 
         :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
         :returns: transcript data as json
         :raises: HTTPError
         """
         if not id_:
             raise ValueError('id_ must be provided')
 
+        url = self._build_transcript_url(self, id_,
+                                         group_channels_by=group_channels_by,
+                                         group_channels_threshold_ms=group_channels_threshold_ms)
+
         response = self._make_http_request(
             "GET",
-            urljoin(self.base_url, 'jobs/{}/transcript'.format(id_)),
+            url,
             headers={'Accept': self.rev_json_content_type}
         )
 
         return response.json()
 
-    def get_transcript_json_as_stream(self, id_):
+    def get_transcript_json_as_stream(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as streamed json.
 
         :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
         :returns: requests.models.Response HTTP response which can be used to stream
             the payload of the response
         :raises: HTTPError
@@ -404,28 +424,38 @@ class RevAiAPIClient(BaseClient):
         if not id_:
             raise ValueError('id_ must be provided')
 
+        url = self._build_transcript_url(self, id_,
+                                         group_channels_by=group_channels_by,
+                                         group_channels_threshold_ms=group_channels_threshold_ms)
+
         response = self._make_http_request(
             "GET",
-            urljoin(self.base_url, 'jobs/{}/transcript'.format(id_)),
+            url,
             headers={'Accept': self.rev_json_content_type},
             stream=True
         )
 
         return response
 
-    def get_transcript_object(self, id_):
+    def get_transcript_object(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
         """Get the transcript of a specific job as a python object`.
 
         :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
         :returns: transcript data as a python object
         :raises: HTTPError
         """
         if not id_:
             raise ValueError('id_ must be provided')
 
+        url = self._build_transcript_url(self, id_,
+                                         group_channels_by=group_channels_by,
+                                         group_channels_threshold_ms=group_channels_threshold_ms)
+
         response = self._make_http_request(
             "GET",
-            urljoin(self.base_url, 'jobs/{}/transcript'.format(id_)),
+            url,
             headers={'Accept': self.rev_json_content_type}
         )
 
@@ -814,3 +844,20 @@ class RevAiAPIClient(BaseClient):
 
     def _create_captions_query(self, speaker_channel):
         return '' if speaker_channel is None else '?speaker_channel={}'.format(speaker_channel)
+    
+    def _build_transcript_url(self, id_, group_channels_by=None, group_channels_threshold_ms=None):
+        """Build the get transcript url.
+
+        :param id_: id of job to be requested
+        :param group_channels_by: optional, group channels by speaker or time
+        :param group_channels_threshold_ms: optional, group channels by time threshold in milliseconds
+        :returns: url for getting the transcript
+        """
+        params = []
+        if group_channels_by is not None:
+            params.append('group_channels_by={}'.format(group_channels_by))
+        if group_channels_threshold_ms is not None:
+            params.append('group_channels_threshold_ms={}'.format(group_channels_threshold_ms))
+
+        query = '?{}'.format('&'.join(params))
+        return urljoin(self.base_url, 'jobs/{}/transcript{}'.format(id_, query))

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -350,7 +350,6 @@ class RevAiAPIClient(BaseClient):
             raise ValueError('id_ must be provided')
         
         url = self._build_transcript_url(
-            self,
             id_,
             group_channels_by=group_channels_by,
             group_channels_threshold_ms=group_channels_threshold_ms
@@ -378,7 +377,6 @@ class RevAiAPIClient(BaseClient):
             raise ValueError('id_ must be provided')
 
         url = self._build_transcript_url(
-            self,
             id_,
             group_channels_by=group_channels_by,
             group_channels_threshold_ms=group_channels_threshold_ms
@@ -406,7 +404,6 @@ class RevAiAPIClient(BaseClient):
             raise ValueError('id_ must be provided')
 
         url = self._build_transcript_url(
-            self,
             id_,
             group_channels_by=group_channels_by,
             group_channels_threshold_ms=group_channels_threshold_ms
@@ -434,7 +431,6 @@ class RevAiAPIClient(BaseClient):
             raise ValueError('id_ must be provided')
 
         url = self._build_transcript_url(
-            self,
             id_,
             group_channels_by=group_channels_by,
             group_channels_threshold_ms=group_channels_threshold_ms
@@ -462,7 +458,6 @@ class RevAiAPIClient(BaseClient):
             raise ValueError('id_ must be provided')
 
         url = self._build_transcript_url(
-            self,
             id_,
             group_channels_by=group_channels_by,
             group_channels_threshold_ms=group_channels_threshold_ms

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -878,8 +878,10 @@ class RevAiAPIClient(BaseClient):
         """Build the get transcript url.
 
         :param id_: id of job to be requested
-        :param group_channels_by: optional, None for default, multichannel transcript grouping strategy
-        :param group_channels_threshold_ms: optional, None for default, grouping threshold, milliseconds
+        :param group_channels_by: optional, GroupChannelsType grouping strategy for
+            multichannel transcripts. None for default.
+        :param group_channels_threshold_ms: optional, grouping threshold in milliseconds.
+            None for default.
         :returns: url for getting the transcript
         """
         params = []

--- a/src/rev_ai/models/__init__.py
+++ b/src/rev_ai/models/__init__.py
@@ -4,7 +4,7 @@
 from .customvocabulary import CustomVocabulary
 from .streaming import MediaConfig
 from .asynchronous import Job, JobStatus, Account, Transcript, Monologue, Element, CaptionType, \
-    SpeakerName
+    SpeakerName, GroupChannelsType
 from .insights import TopicExtractionJob, TopicExtractionResult, Topic, Informant, \
     SentimentAnalysisResult, SentimentValue, SentimentMessage, SentimentAnalysisJob
 from .language_id import LanguageIdentificationJob, LanguageIdentificationResult, LanguageConfidence

--- a/src/rev_ai/models/asynchronous/__init__.py
+++ b/src/rev_ai/models/asynchronous/__init__.py
@@ -7,3 +7,4 @@ from .job_status import JobStatus
 from .account import Account
 from .transcript import Transcript, Monologue, Element
 from .speaker_name import SpeakerName
+from .group_channels_type import GroupChannelsType

--- a/src/rev_ai/models/asynchronous/group_channels_type.py
+++ b/src/rev_ai/models/asynchronous/group_channels_type.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Enum for caption content types"""
+
+from enum import Enum
+
+
+class GroupChannelsType(Enum):
+    SPEAKER = 'speaker'
+    SENTENCE = 'sentence'
+    WORD = 'word'
+
+    @classmethod
+    def from_string(cls, status):
+        return cls[status.upper()]

--- a/src/rev_ai/models/asynchronous/group_channels_type.py
+++ b/src/rev_ai/models/asynchronous/group_channels_type.py
@@ -4,7 +4,7 @@
 from enum import Enum
 
 
-class GroupChannelsType(Enum):
+class GroupChannelsType(str, Enum):
     SPEAKER = 'speaker'
     SENTENCE = 'sentence'
     WORD = 'word'

--- a/src/rev_ai/models/asynchronous/group_channels_type.py
+++ b/src/rev_ai/models/asynchronous/group_channels_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Enum for caption content types"""
+"""Enum for group_channels_by types"""
 
 from enum import Enum
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -34,25 +34,57 @@ class TestTranscriptEndpoints():
         mock_session.request.assert_called_once_with("GET",
                                                      URL,
                                                      headers=expected_headers)
-
-    @pytest.mark.parametrize('id', [None, ''])
-    def test_get_transcript_text_with_no_job_id(self, id, mock_session):
-        with pytest.raises(ValueError, match='id_ must be provided'):
-            RevAiAPIClient(TOKEN).get_transcript_text(id)
-
-    def test_get_transcript_text_as_stream(self, mock_session, make_mock_response):
+        
+    @pytest.mark.parametrize('group_channels_by, group_channels_threshold_ms', [(None, None), ('sentence', 5000), ('word', 2000)])
+    def test_get_transcript_text(self, mock_session, make_mock_response, group_channels_by, group_channels_threshold_ms):
         data = 'Test'
         client = RevAiAPIClient(TOKEN)
         expected_headers = {'Accept': 'text/plain'}
         expected_headers.update(client.default_headers)
         response = make_mock_response(url=URL, text=data)
         mock_session.request.return_value = response
+        expected_url = URL
+        if group_channels_by and group_channels_threshold_ms:
+            expected_url += f"?group_channels_by={group_channels_by}&group_channels_threshold_ms={group_channels_threshold_ms}"
 
-        res = client.get_transcript_text_as_stream(JOB_ID)
+        res = client.get_transcript_text(JOB_ID, group_channels_by=group_channels_by, group_channels_threshold_ms=group_channels_threshold_ms)
+
+        assert res == data
+        mock_session.request.assert_called_once_with("GET",
+                                                     expected_url,
+                                                     headers=expected_headers)
+
+    @pytest.mark.parametrize('id', [None, ''])
+    def test_get_transcript_text_with_no_job_id(self, id, mock_session):
+        with pytest.raises(ValueError, match='id_ must be provided'):
+            RevAiAPIClient(TOKEN).get_transcript_text(id)
+
+    @pytest.mark.parametrize(
+        'group_channels_by, group_channels_threshold_ms',
+        [(None, None), ('sentence', 5000), ('word', 2000)]
+    )
+    def test_get_transcript_text_as_stream(
+        self,
+        mock_session,
+        make_mock_response,
+        group_channels_by,
+        group_channels_threshold_ms
+    ):
+        data = 'Test'
+        client = RevAiAPIClient(TOKEN)
+        expected_headers = {'Accept': 'text/plain'}
+        expected_headers.update(client.default_headers)
+        response = make_mock_response(url=URL, text=data)
+        mock_session.request.return_value = response
+        expected_url = URL
+        if group_channels_by and group_channels_threshold_ms:
+            expected_url += f"?group_channels_by={group_channels_by}&group_channels_threshold_ms={group_channels_threshold_ms}"
+
+        res = client.get_transcript_text_as_stream(JOB_ID, group_channels_by=group_channels_by, group_channels_threshold_ms=group_channels_threshold_ms)
 
         assert res.content == data
         mock_session.request.assert_called_once_with("GET",
-                                                     URL,
+                                                     expected_url,
                                                      headers=expected_headers,
                                                      stream=True)
 
@@ -61,7 +93,17 @@ class TestTranscriptEndpoints():
         with pytest.raises(ValueError, match='id_ must be provided'):
             RevAiAPIClient(TOKEN).get_transcript_text_as_stream(id)
 
-    def test_get_transcript_json(self, mock_session, make_mock_response):
+    @pytest.mark.parametrize(
+        'group_channels_by, group_channels_threshold_ms',
+        [(None, None), ('sentence', 5000), ('word', 2000)]
+    )
+    def test_get_transcript_json(
+        self,
+        mock_session,
+        make_mock_response,
+        group_channels_by,
+        group_channels_threshold_ms
+    ):
         data = {
             'monologues': [{
                 'speaker': 1,
@@ -80,19 +122,32 @@ class TestTranscriptEndpoints():
         expected_headers.update(client.default_headers)
         response = make_mock_response(url=URL, json_data=data)
         mock_session.request.return_value = response
+        expected_url = URL
+        if group_channels_by and group_channels_threshold_ms:
+            expected_url += f"?group_channels_by={group_channels_by}&group_channels_threshold_ms={group_channels_threshold_ms}"
 
-        res = client.get_transcript_json(JOB_ID)
+        res = client.get_transcript_json(JOB_ID, group_channels_by=group_channels_by, group_channels_threshold_ms=group_channels_threshold_ms)
 
         assert res == expected
         mock_session.request.assert_called_once_with(
-            "GET", URL, headers=expected_headers)
+            "GET", expected_url, headers=expected_headers)
 
     @pytest.mark.parametrize('id', [None, ''])
     def test_get_transcript_json_with_no_job_id(self, id, mock_session):
         with pytest.raises(ValueError, match='id_ must be provided'):
             RevAiAPIClient(TOKEN).get_transcript_json(id)
 
-    def test_get_transcript_json_as_stream(self, mock_session, make_mock_response):
+    @pytest.mark.parametrize(
+        'group_channels_by, group_channels_threshold_ms',
+        [(None, None), ('sentence', 5000), ('word', 2000)]
+    )
+    def test_get_transcript_json_as_stream(
+        self,
+        mock_session,
+        make_mock_response,
+        group_channels_by,
+        group_channels_threshold_ms
+    ):
         data = {
             'monologues': [{
                 'speaker': 1,
@@ -111,19 +166,32 @@ class TestTranscriptEndpoints():
         expected_headers.update(client.default_headers)
         response = make_mock_response(url=URL, json_data=data)
         mock_session.request.return_value = response
+        expected_url = URL
+        if group_channels_by and group_channels_threshold_ms:
+            expected_url += f"?group_channels_by={group_channels_by}&group_channels_threshold_ms={group_channels_threshold_ms}"
 
-        res = client.get_transcript_json_as_stream(JOB_ID)
+        res = client.get_transcript_json_as_stream(JOB_ID, group_channels_by=group_channels_by, group_channels_threshold_ms=group_channels_threshold_ms)
 
         assert json.loads(res.content.decode('utf-8').replace("\'", "\"")) == expected
         mock_session.request.assert_called_once_with(
-            "GET", URL, headers=expected_headers, stream=True)
+            "GET", expected_url, headers=expected_headers, stream=True)
 
     @pytest.mark.parametrize('id', [None, ''])
     def test_get_transcript_json_as_stream_with_no_job_id(self, id, mock_session):
         with pytest.raises(ValueError, match='id_ must be provided'):
             RevAiAPIClient(TOKEN).get_transcript_json_as_stream(id)
 
-    def test_get_transcript_object_with_success(self, mock_session, make_mock_response):
+    @pytest.mark.parametrize(
+        'group_channels_by, group_channels_threshold_ms',
+        [(None, None), ('sentence', 5000), ('word', 2000)]
+    )
+    def test_get_transcript_object_with_success(
+        self,
+        mock_session,
+        make_mock_response,
+        group_channels_by,
+        group_channels_threshold_ms
+    ):
         data = {
             'monologues': [{
                 'speaker': 1,
@@ -142,12 +210,15 @@ class TestTranscriptEndpoints():
         expected_headers.update(client.default_headers)
         response = make_mock_response(url=URL, json_data=data)
         mock_session.request.return_value = response
+        expected_url = URL
+        if group_channels_by and group_channels_threshold_ms:
+            expected_url += f"?group_channels_by={group_channels_by}&group_channels_threshold_ms={group_channels_threshold_ms}"
 
-        res = client.get_transcript_object(JOB_ID)
+        res = client.get_transcript_object(JOB_ID, group_channels_by=group_channels_by, group_channels_threshold_ms=group_channels_threshold_ms)
 
         assert res == expected
         mock_session.request.assert_called_once_with(
-            "GET", URL, headers=expected_headers)
+            "GET", expected_url, headers=expected_headers)
 
     @pytest.mark.parametrize('id', [None, ''])
     def test_get_transcript_object_with_no_job_id(self, id, mock_session):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -6,6 +6,7 @@ import json
 from src.rev_ai.apiclient import RevAiAPIClient
 from src.rev_ai.models import RevAiApiDeploymentConfigMap, RevAiApiDeployment
 from src.rev_ai.models.asynchronous import Transcript, Monologue, Element
+from src.rev_ai.models.asynchronous.group_channels_type import GroupChannelsType
 
 try:
     from urllib.parse import urljoin
@@ -20,8 +21,17 @@ URL = urljoin(SPEECH_TO_TEXT_URL, 'jobs/{}/transcript'.format(JOB_ID))
 
 @pytest.mark.usefixtures('mock_session', 'make_mock_response')
 class TestTranscriptEndpoints():
-    @pytest.mark.parametrize('group_channels_by, group_channels_threshold_ms', [(None, None), ('sentence', 5000), ('word', 2000)])
-    def test_get_transcript_text(self, mock_session, make_mock_response, group_channels_by, group_channels_threshold_ms):
+    @pytest.mark.parametrize(
+        'group_channels_by, group_channels_threshold_ms',
+        [(None, None), (GroupChannelsType.SENTENCE, 5000), (GroupChannelsType.WORD, 2000)]
+    )
+    def test_get_transcript_text(
+        self,
+        mock_session,
+        make_mock_response,
+        group_channels_by,
+        group_channels_threshold_ms
+    ):
         data = 'Test'
         client = RevAiAPIClient(TOKEN)
         expected_headers = {'Accept': 'text/plain'}
@@ -46,7 +56,7 @@ class TestTranscriptEndpoints():
 
     @pytest.mark.parametrize(
         'group_channels_by, group_channels_threshold_ms',
-        [(None, None), ('sentence', 5000), ('word', 2000)]
+        [(None, None), (GroupChannelsType.SENTENCE, 5000), (GroupChannelsType.WORD, 2000)]
     )
     def test_get_transcript_text_as_stream(
         self,
@@ -80,7 +90,7 @@ class TestTranscriptEndpoints():
 
     @pytest.mark.parametrize(
         'group_channels_by, group_channels_threshold_ms',
-        [(None, None), ('sentence', 5000), ('word', 2000)]
+        [(None, None), (GroupChannelsType.SENTENCE, 5000), (GroupChannelsType.WORD, 2000)]
     )
     def test_get_transcript_json(
         self,
@@ -124,7 +134,7 @@ class TestTranscriptEndpoints():
 
     @pytest.mark.parametrize(
         'group_channels_by, group_channels_threshold_ms',
-        [(None, None), ('sentence', 5000), ('word', 2000)]
+        [(None, None), (GroupChannelsType.SENTENCE, 5000), (GroupChannelsType.WORD, 2000)]
     )
     def test_get_transcript_json_as_stream(
         self,
@@ -168,7 +178,7 @@ class TestTranscriptEndpoints():
 
     @pytest.mark.parametrize(
         'group_channels_by, group_channels_threshold_ms',
-        [(None, None), ('sentence', 5000), ('word', 2000)]
+        [(None, None), (GroupChannelsType.SENTENCE, 5000), (GroupChannelsType.WORD, 2000)]
     )
     def test_get_transcript_object_with_success(
         self,

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -20,21 +20,6 @@ URL = urljoin(SPEECH_TO_TEXT_URL, 'jobs/{}/transcript'.format(JOB_ID))
 
 @pytest.mark.usefixtures('mock_session', 'make_mock_response')
 class TestTranscriptEndpoints():
-    def test_get_transcript_text(self, mock_session, make_mock_response):
-        data = 'Test'
-        client = RevAiAPIClient(TOKEN)
-        expected_headers = {'Accept': 'text/plain'}
-        expected_headers.update(client.default_headers)
-        response = make_mock_response(url=URL, text=data)
-        mock_session.request.return_value = response
-
-        res = client.get_transcript_text(JOB_ID)
-
-        assert res == data
-        mock_session.request.assert_called_once_with("GET",
-                                                     URL,
-                                                     headers=expected_headers)
-        
     @pytest.mark.parametrize('group_channels_by, group_channels_threshold_ms', [(None, None), ('sentence', 5000), ('word', 2000)])
     def test_get_transcript_text(self, mock_session, make_mock_response, group_channels_by, group_channels_threshold_ms):
         data = 'Test'


### PR DESCRIPTION
## Overview
Add new optional parameters to `get_transcript_xx` functions that are available for multichannel media files:
1. `group_channels_by`
Specifies how to group multiple channels in the transcript. This parameter determines the atomic entity for breaking down the transcript into monologues. Only applicable when the submitted media has multiple channels (speaker_channels_count > 1):

- `speaker` - groups by speakers
- `word` - groups by individual words
- `sentence` - groups by complete sentences

2. `group_channels_threshold_ms`
Threshold in milliseconds for handling speaker interruptions. When a speaker interrupts another speaker, this parameter determines how to group the segments. Only applicable when the submitted media has multiple channels (speaker_channels_count > 1):
- If the interruption occurs within this threshold, preference is given to the most recent speaker
- If the interruption occurs after this threshold, a new segment is created

## Usage
```
from rev_ai import apiclient, GroupChannelsType

client = apiclient.RevAiAPIClient(token)
job = client.submit_job_local_file(filePath, speaker_channels_count=2)

# default (word, 1000ms)
transcript = client.get_transcript_text(job.id)

# specific WORD params
transcript_word = client.get_transcript_text(job.id, group_channels_by=GroupChannelsType.WORD, group_channels_threshold_ms=1000)

# specific Sentence parameters
transcript_sentence = client.get_transcript_text(job.id, group_channels_by=GroupChannelsType.SENTENCE, group_channels_threshold_ms=2000)

# Speaker parameter
transcript_speaker = client.get_transcript_text(job.id, group_channels_by=GroupChannelsType.SPEAKER)

```