### PR TITLE
REVAI-4573: Update SDKs to support new model

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,7 +38,7 @@ jobs:
         pip install --upgrade pip
         pip install -r requirements.txt -r requirements_dev.txt
     - name: Test
-      run: python setup.py test
+      run: pytest tests/
     - name: Lint
       run: |
         flake8 tests --ignore=F401,W504,E731,E123,E125,E127,E128,E501

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,5 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
     ],
-    setup_requires=['pytest-runner==4.2'],
-    test_suite='tests',
-    tests_require=test_requirements,
     url='https://github.com/revdotcom/revai-python-sdk',
 )

--- a/src/rev_ai/__init__.py
+++ b/src/rev_ai/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Top-level package for rev_ai"""
 
-__version__ = '2.21.0'
+__version__ = '2.22.0'
 
 from .models import Job, JobStatus, Account, Transcript, Monologue, Element, MediaConfig, \
     CaptionType, GroupChannelsType, CustomVocabulary, TopicExtractionJob, TopicExtractionResult, \

--- a/src/rev_ai/apiclient.py
+++ b/src/rev_ai/apiclient.py
@@ -817,7 +817,11 @@ class RevAiAPIClient(BaseClient):
             translation_config: TranslationOptions = None):
         payload = {}
         if media_url:
-            payload['media_url'] = media_url
+            if source_config:
+                raise ValueError(
+                    'media_url is not compatible with source_config. '
+                    'Use source_config for all URL-based submissions.')
+            payload['source_config'] = {'url': media_url}
         if skip_diarization:
             payload['skip_diarization'] = skip_diarization
         if skip_punctuation:
@@ -842,7 +846,7 @@ class RevAiAPIClient(BaseClient):
             payload['custom_vocabulary_id'] = custom_vocabulary_id
         if transcriber:
             payload['transcriber'] = transcriber
-        if verbatim:
+        if verbatim is not None:
             payload['verbatim'] = verbatim
         if rush:
             payload['rush'] = rush

--- a/tests/test_async_summarization.py
+++ b/tests/test_async_summarization.py
@@ -112,7 +112,7 @@ class TestAsyncSummarization():
             "POST",
             JOBS_URL,
             json={
-                'media_url': 'https://example.com/test.mp3',
+                'source_config': {'url': 'https://example.com/test.mp3'},
                 'language': 'en',
                 'summarization_config': {
                     'prompt': "Try to summarize this transcript as good as you possibly can",

--- a/tests/test_async_translation.py
+++ b/tests/test_async_translation.py
@@ -147,7 +147,7 @@ class TestAsyncTranslation():
             "POST",
             JOBS_URL,
             json={
-                'media_url': 'https://example.com/test.mp3',
+                'source_config': {'url': 'https://example.com/test.mp3'},
                 'language': 'en',
                 'translation_config': {
                     'target_languages': [

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -162,7 +162,7 @@ class TestJobEndpoints():
             "POST",
             JOBS_URL,
             json={
-                'media_url': SOURCE_URL,
+                'source_config': {'url': SOURCE_URL},
                 'callback_url': NOTIFICATION_URL,
                 'metadata': METADATA,
                 'skip_diarization': True,
@@ -276,13 +276,84 @@ class TestJobEndpoints():
             'POST',
             JOBS_URL,
             json={
-                'media_url': SOURCE_URL,
+                'source_config': {'url': SOURCE_URL},
                 'transcriber': 'human',
                 'verbatim': True,
                 'segments_to_transcribe': segments,
                 'speaker_names': [{'display_name': 'Kyle Bridburg'}]
             },
             headers=client.default_headers)
+
+    def test_submit_job_url_with_media_url_and_source_config_conflict(self, mock_session):
+        """Passing both media_url and source_config should raise ValueError."""
+        client = RevAiAPIClient(TOKEN)
+
+        with pytest.raises(ValueError, match='media_url is not compatible with source_config'):
+            client.submit_job_url(
+                media_url=SOURCE_URL,
+                source_config=SOURCE_CONFIG
+            )
+
+    def test_submit_job_url_verbatim_false(self, mock_session, make_mock_response):
+        """verbatim=False should be included in payload."""
+        data = {
+            'id': JOB_ID,
+            'status': 'in_progress',
+            'created_on': CREATED_ON,
+        }
+        response = make_mock_response(url=JOB_ID_URL, json_data=data)
+        mock_session.request.return_value = response
+        client = RevAiAPIClient(TOKEN)
+
+        client.submit_job_url(SOURCE_URL, verbatim=False)
+
+        mock_session.request.assert_called_once_with(
+            'POST',
+            JOBS_URL,
+            json={
+                'source_config': {'url': SOURCE_URL},
+                'verbatim': False,
+            },
+            headers=client.default_headers)
+
+    def test_submit_job_url_verbatim_true(self, mock_session, make_mock_response):
+        """verbatim=True should be included in payload."""
+        data = {
+            'id': JOB_ID,
+            'status': 'in_progress',
+            'created_on': CREATED_ON,
+        }
+        response = make_mock_response(url=JOB_ID_URL, json_data=data)
+        mock_session.request.return_value = response
+        client = RevAiAPIClient(TOKEN)
+
+        client.submit_job_url(SOURCE_URL, verbatim=True)
+
+        mock_session.request.assert_called_once_with(
+            'POST',
+            JOBS_URL,
+            json={
+                'source_config': {'url': SOURCE_URL},
+                'verbatim': True,
+            },
+            headers=client.default_headers)
+
+    def test_submit_job_url_verbatim_none(self, mock_session, make_mock_response):
+        """verbatim=None (default) should NOT be included in payload."""
+        data = {
+            'id': JOB_ID,
+            'status': 'in_progress',
+            'created_on': CREATED_ON,
+        }
+        response = make_mock_response(url=JOB_ID_URL, json_data=data)
+        mock_session.request.return_value = response
+        client = RevAiAPIClient(TOKEN)
+
+        client.submit_job_url(SOURCE_URL)
+
+        call_kwargs = mock_session.request.call_args
+        payload = call_kwargs[1]['json'] if 'json' in call_kwargs[1] else call_kwargs[0][2]
+        assert 'verbatim' not in payload
 
     def test_submit_job_local_file_with_success(self, mocker, mock_session, make_mock_response):
         created_on = '2018-05-05T23:23:22.29Z'


### PR DESCRIPTION
## Description of Work

Migrates the Python SDK's speech-to-text `submit_job_url` to use `source_config` instead of `media_url`, enabling support for the v3 transcriber (`machine_v3`). Also fixes the `verbatim` option to be sent when explicitly set to `False` (previously skipped due to a falsy check).

### What Changed

- **`src/rev_ai/apiclient.py`** — `_create_job_options_payload`:
  - `media_url` param now builds `source_config: {url: media_url}` in the payload instead of sending `media_url` directly
  - Added conflict validation: raises `ValueError` if both `media_url` and `source_config` are provided
  - Fixed `if verbatim:` → `if verbatim is not None:` so `verbatim=False` is correctly sent to the API
- **Tests** (TDD approach — tests committed first, verified failing, then implementation committed):
  - Updated existing assertions from `media_url` to `source_config` in job, summarization, and translation tests
  - Added new tests: `media_url`/`source_config` conflict, `verbatim=True`, `verbatim=False`, `verbatim=None`

## Screenshots

### Integration test script (`test_source_config_migration.py`)

```python
"""
REVAI-4573: Integration test script for source_config migration.

Demonstrates that submit_job_url now sends source_config instead of media_url,
enabling v3 transcriber support. Also verifies verbatim=False is sent correctly
and that media_url + source_config conflict raises ValueError.
"""

import sys
sys.path.insert(0, 'src')

from rev_ai import apiclient
from rev_ai.models.customer_url_data import CustomerUrlData

LOCAL_API = "http://localhost:5000"
TOKEN = "<your_token>"
MEDIA_URL = "https://www.rev.ai/FTC_Sample_1.mp3"


def test_submit_job_url_sends_source_config():
    """Test 1: submit_job_url(media_url=...) sends source_config in payload."""
    print("=" * 60)
    print("TEST 1: submit_job_url sends source_config instead of media_url")
    print("=" * 60)
    client = apiclient.RevAiAPIClient(TOKEN, url=LOCAL_API)
    try:
        job = client.submit_job_url(
            media_url=MEDIA_URL,
            transcriber='machine_v3',
            language='en'
        )
        print(f"  Job ID:     {job.id}")
        print(f"  Status:     {job.status}")
        print(f"  Created:    {job.created_on}")
        print("  RESULT: PASS")
    except Exception as e:
        print(f"  Response/Error: {e}")
        print("  RESULT: FAIL (see error above)")
    print()


def test_submit_job_url_with_source_config_object():
    """Test 2: submit_job_url(source_config=CustomerUrlData(...)) still works."""
    print("=" * 60)
    print("TEST 2: submit_job_url with source_config object directly")
    print("=" * 60)
    client = apiclient.RevAiAPIClient(TOKEN, url=LOCAL_API)
    try:
        job = client.submit_job_url(
            source_config=CustomerUrlData(
                url=MEDIA_URL,
                auth_headers={"Authorization": "Bearer media_token"}
            ),
            transcriber='machine_v3',
            language='en'
        )
        print(f"  Job ID:     {job.id}")
        print(f"  Status:     {job.status}")
        print(f"  Created:    {job.created_on}")
        print("  RESULT: PASS")
    except Exception as e:
        print(f"  Response/Error: {e}")
        print("  RESULT: FAIL (see error above)")
    print()


def test_media_url_and_source_config_conflict():
    """Test 3: Passing both media_url and source_config raises ValueError."""
    print("=" * 60)
    print("TEST 3: media_url + source_config conflict raises ValueError")
    print("=" * 60)
    client = apiclient.RevAiAPIClient(TOKEN, url=LOCAL_API)
    try:
        client.submit_job_url(
            media_url=MEDIA_URL,
            source_config=CustomerUrlData(url=MEDIA_URL)
        )
        print("  RESULT: FAIL (no error raised)")
    except ValueError as e:
        print(f"  ValueError: {e}")
        print("  RESULT: PASS")
    except Exception as e:
        print(f"  Unexpected error: {e}")
        print("  RESULT: FAIL")
    print()


def test_verbatim_false_is_sent():
    """Test 4: verbatim=False is included in the payload."""
    print("=" * 60)
    print("TEST 4: verbatim=False is sent in payload")
    print("=" * 60)
    client = apiclient.RevAiAPIClient(TOKEN, url=LOCAL_API)
    try:
        job = client.submit_job_url(
            media_url=MEDIA_URL,
            transcriber='machine_v3',
            verbatim=False,
            language='en'
        )
        print(f"  Job ID:     {job.id}")
        print(f"  Status:     {job.status}")
        print(f"  Verbatim:   {job.verbatim}")
        print("  RESULT: PASS")
    except Exception as e:
        print(f"  Response/Error: {e}")
        print("  RESULT: FAIL (see error above)")
    print()


if __name__ == '__main__':
    print(f"Rev AI Python SDK — source_config migration test")
    print(f"API endpoint: {LOCAL_API}")
    print()
    test_submit_job_url_sends_source_config()
    test_submit_job_url_with_source_config_object()
    test_media_url_and_source_config_conflict()
    test_verbatim_false_is_sent()
    print("All tests completed.")
```

### Test run output (against local API on localhost:5000)

```
Rev AI Python SDK — source_config migration test
API endpoint: http://localhost:5000

============================================================
TEST 1: submit_job_url sends source_config instead of media_url
============================================================
  Job ID:     NhZpnf4hLCQV
  Status:     in_progress
  Created:    2026-02-19T13:12:09.322Z
  RESULT: PASS

============================================================
TEST 2: submit_job_url with source_config object directly
============================================================
  Job ID:     gUDieEdBoHeo
  Status:     in_progress
  Created:    2026-02-19T13:12:09.338Z
  RESULT: PASS

============================================================
TEST 3: media_url + source_config conflict raises ValueError
============================================================
  ValueError: media_url is not compatible with source_config. Use source_config for all URL-based submissions.
  RESULT: PASS

============================================================
TEST 4: verbatim=False is sent in payload
============================================================
  Job ID:     QGgphget9T0I
  Status:     in_progress
  Verbatim:   False
  RESULT: PASS

All tests completed.
```

## Additional Comments

Changes are scoped to the speech-to-text API client only (`RevAiAPIClient`). The `GenericApiClient` used by language identification, sentiment analysis, and topic extraction clients is untouched.